### PR TITLE
Update endpoints.py

### DIFF
--- a/mdx_oembed/endpoints.py
+++ b/mdx_oembed/endpoints.py
@@ -4,13 +4,13 @@ import oembed
 
 ENDPOINTS = {
     'youtube': oembed.OEmbedEndpoint('http://www.youtube.com/oembed', [
-        'http://(*.)?youtube.com/*',
-        'http://youtu.be/*',
+        'https?://(*.)?youtube.com/*',
+        'https?://youtu.be/*',
     ]),
     'flickr': oembed.OEmbedEndpoint('http://www.flickr.com/services/oembed/', [
-        'http://*.flickr.com/*',
+        'https?://*.flickr.com/*',
     ]),
     'vimeo': oembed.OEmbedEndpoint('http://vimeo.com/api/oembed.json', [
-        'http://vimeo.com/*',
+        'https?://vimeo.com/*',
     ]),
 }


### PR DESCRIPTION
Many websites are using https, often by default. This allows https links to be recognized as well.
