### PR TITLE
Add compatibility with Markdown 2.6

### DIFF
--- a/mdx_oembed/__init__.py
+++ b/mdx_oembed/__init__.py
@@ -2,10 +2,8 @@
 from mdx_oembed.extension import OEmbedExtension
 
 
-VERSION = '0.1.4'
+VERSION = '0.1.5'
 
 
-def makeExtension(configs=None):
-    if isinstance(configs, list):
-        configs = dict(configs)
-    return OEmbedExtension(configs=configs)
+def makeExtension(**kwargs):
+    return OEmbedExtension(**kwargs)

--- a/mdx_oembed/extension.py
+++ b/mdx_oembed/extension.py
@@ -10,13 +10,15 @@ AVAILABLE_ENDPOINTS = ENDPOINTS.keys()
 
 class OEmbedExtension(Extension):
 
-    config = {
-        'allowed_endpoints': [
-            AVAILABLE_ENDPOINTS,
-            "A list of oEmbed endpoints to allow. Possible values are "
-            "{}.".format(', '.join(AVAILABLE_ENDPOINTS)),
-        ],
-    }
+    def __init__(self, **kwargs):
+        self.config = {
+            'allowed_endpoints': [
+                AVAILABLE_ENDPOINTS,
+                "A list of oEmbed endpoints to allow. Possible values are "
+                "{}.".format(', '.join(AVAILABLE_ENDPOINTS)),
+            ],
+        }
+        super(OEmbedExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md, md_globals):
         self.oembed_consumer = self.prepare_oembed_consumer()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception:
 
 setup(
     name='python-markdown-oembed',
-    version='0.1.4',
+    version='0.1.5',
     description="Markdown extension to allow media embedding using the oEmbed "
                 "standard.",
     long_description=LONG_DESCRIPTION,
@@ -36,7 +36,7 @@ setup(
     ],
     install_requires=[
         "python-oembed >= 0.2.1",
-        "Markdown >= 2.2.0",
+        "Markdown >= 2.6.0",
     ],
 
     test_suite='nose.collector',


### PR DESCRIPTION
Add compatibility with Markdown 2.6 at the cost of dropping compatibility with earlier Markdown versions. This is due to a backwards-incompatible change in the python-markdown extension api introduced in 2.6. The configs keyword doesn't work anymore.

See https://pythonhosted.org/Markdown/release-2.6.html#the-configs-keyword-is-deprecated