### PR TITLE
Add support for Python-Markdown safe mode

### DIFF
--- a/mdx_oembed/inlinepatterns.py
+++ b/mdx_oembed/inlinepatterns.py
@@ -21,7 +21,7 @@ class OEmbedLinkPattern(Pattern):
         html = self.get_oembed_html_for_match(match)
         if html is None:
             return None
-        placeholder = self.markdown.htmlStash.store(html)
+        placeholder = self.markdown.htmlStash.store(html, True)
         return placeholder
 
     def get_oembed_html_for_match(self, match):


### PR DESCRIPTION
Mark OEmbed's html result as safe so the embedded content doesn't get stripped or escaped when using Python-Markdown's safe mode.